### PR TITLE
Adiciona pipeline ao projeto

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,43 @@
+stages:
+  - test
+  - build
+  - deploy
+
+variables:
+  LINO_LATEST_IMAGE: $DOCKER_USER/webcrawler:latest
+
+test_flake8:
+  image: ejplatform/python:alpine
+  stage: test
+  script:
+    - flake8
+  only:
+    - /master/
+    - /devel/
+
+build webcrawler:
+  image: docker:latest
+  stage: build
+  services:
+    - docker:dind
+  script:
+    - docker build -t $LINO_LATEST_IMAGE .
+    - docker login -u $DOCKER_USER -p $DOCKER_PASS
+    - docker push $LINO_LATEST_IMAGE
+  only:
+    - /master/
+  environment: production
+
+deploy_production:
+  image: cdrx/rancher-gitlab-deploy
+  stage: deploy
+  script:
+    - "upgrade
+            --service lino-webcrawler
+            --environment $RANCHER_ENVIRONMENT
+            --stack $RANCHER_STACK
+            --rancher-key $RANCHER_ACCESS_KEY
+            --rancher-secret $RANCHER_SECRET_KEY
+            --rancher-url $RANCHER_URL"
+  only:
+    - /master/


### PR DESCRIPTION
Adiciona o gitlabci ao projeto para que seja implementado o pipeline de deploy

refs: fga-eps-mds/2018.2-Lino#94
