### PR TITLE
Arruma build do cronjob

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,7 @@ build cronjob:
   before_script:
     - docker login -u $DOCKER_USER -p $DOCKER_PASS
   script:
-    - docker build -t $CRONJOB_LATEST_IMAGE .
+    - docker build -t $CRONJOB_LATEST_IMAGE -f Cronjob.Dockerfile .
     - docker push $CRONJOB_LATEST_IMAGE
   only:
     - /master/


### PR DESCRIPTION
O stage de build do cronjob no .gitlab-ci.yml estava errado, logo o cronjob não estava funcionando pois a imagem do docker gerada era uma imagem errada. Esse PR arruma esse problema, passando o arquivo certo no stage de build do pipeline.