### PR TITLE
Cria pipeline de homologação

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,8 +4,8 @@ stages:
   - deploy
 
 variables:
-  LINO_LATEST_IMAGE: $DOCKER_USER/webcrawler:latest
-  CRONJOB_LATEST_IMAGE: $DOCKER_USER/cronjob-webcrawler-ru:latest
+  LINO_LATEST_IMAGE: $DOCKER_USER/webcrawler
+  CRONJOB_LATEST_IMAGE: $DOCKER_USER/cronjob-webcrawler-ru
 
 ##############################################################################
 #                                 Test stage                                 #
@@ -55,6 +55,20 @@ build webcrawler:
     - /master/
   environment: production
 
+build webcrawler homolog:
+  image: docker:latest
+  stage: build
+  services:
+    - docker:dind
+  before_script:
+    - docker login -u $DOCKER_USER -p $DOCKER_PASS
+  script:
+    - docker build -t $LINO_LATEST_IMAGE:homolog .
+    - docker push $LINO_LATEST_IMAGE:homolog
+  only:
+    - /devel/
+    - /ciHomolog/
+
 build cronjob:
   image: docker:latest
   stage: build
@@ -67,6 +81,20 @@ build cronjob:
     - docker push $CRONJOB_LATEST_IMAGE
   only:
     - /master/
+
+build cronjob homoloh:
+  image: docker:latest
+  stage: build
+  services:
+    - docker:dind
+  before_script:
+    - docker login -u $DOCKER_USER -p $DOCKER_PASS
+  script:
+    - docker build -t $CRONJOB_LATEST_IMAGE:homolog -f Cronjob.Dockerfile .
+    - docker push $CRONJOB_LATEST_IMAGE:homolog
+  only:
+    - /devel/
+    - ciHomolog
 
 
 ##############################################################################
@@ -87,6 +115,20 @@ deploy webcrawler production:
   only:
     - /master/
 
+deploy webcrawler homolog:
+  image: cdrx/rancher-gitlab-deploy
+  stage: deploy
+  script:
+        - "upgrade
+            --rancher-url $RANCHER_HOMOLOG_URL
+            --rancher-key $RANCHER_HOMOLOG_ACCESS_KEY
+            --rancher-secret $RANCHER_HOMOLOG_SECRET_KEY
+            --environment $RANCHER_ENVIRONMENT
+            --stack $RANCHER_STACK
+            --service webcrawler-lino"
+  only:
+    - /devel/
+
 deploy cronjob production:
   image: cdrx/rancher-gitlab-deploy
   stage: deploy
@@ -100,3 +142,17 @@ deploy cronjob production:
             --rancher-url $RANCHER_URL"
   only:
     - /master/
+
+deploy cronjob homolog:
+  image: cdrx/rancher-gitlab-deploy
+  stage: deploy
+  script:
+        - "upgrade
+            --rancher-url $RANCHER_HOMOLOG_URL
+            --rancher-key $RANCHER_HOMOLOG_ACCESS_KEY
+            --rancher-secret $RANCHER_HOMOLOG_SECRET_KEY
+            --environment $RANCHER_ENVIRONMENT
+            --stack $RANCHER_STACK
+            --service cronjob-webcrawler-ru"
+  only:
+    - /devel/


### PR DESCRIPTION
## Descrição

Detectamos um risco que é depender somente do servidor onde está hospedado o Lino. Assim, decidimos criar um ambiente de homologação que está utlizando da Digital Ocean.

Então criamos um pipeline para que utilize a branch devel para subir pro ambiente de homologação. Assim, temos três estágios test/build/deploy para verificar a estrutura do código e enviar para a homologação.